### PR TITLE
There's no whitespace after the bottom of the attendee list

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -17,6 +17,7 @@
 #content {
     width: 1100px;
     margin-top: 25px;
+    margin-bottom: 50px;
     margin-left: auto;
     margin-right: auto;
 }


### PR DESCRIPTION
If the announcements and attendee list are long enough to make the page require scrolling, the attendee list goes all the way to the bottom of the page.
